### PR TITLE
Kaspersky deletes Ignis upon download

### DIFF
--- a/mining_tool_instruction/others/en.html
+++ b/mining_tool_instruction/others/en.html
@@ -1,5 +1,5 @@
 Freedom! tries to work with many different antivirus companies to whitelist the official Crypto miner software.
-Sometimes we still get a false positive and the antivirus software will block the installation or normal operation of the program. (Take note: That Kaspersky is one of the known antivirus that doesn't work)
+Sometimes we still get a false positive and the antivirus software will block the installation or normal operation of the program. (Take note: That Kaspersky is one of the known antiviruses that doesn't work)
 Please make an exception for the miners folders location in your antivirus software and the program should work without problems.
 If you still experience problems related to antivirus software, please do contact your antivirus provider company.
 

--- a/mining_tool_instruction/others/en.html
+++ b/mining_tool_instruction/others/en.html
@@ -1,7 +1,7 @@
-Freedom! tries to work with many different antivirus companies to whitelist the official Crypto miner software. 
-Sometimes we still get a false positive and the antivirus software will block the installation or normal operation of the program. (Take note: That Kaspersky is one of the know antivirus that doesn't work) 
-Please make an exception for the miners folders location in your antivirus software and the program should work without problems. 
+Freedom! tries to work with many different antivirus companies to whitelist the official Crypto miner software.
+Sometimes we still get a false positive and the antivirus software will block the installation or normal operation of the program. (Take note: That Kaspersky is one of the known antivirus that doesn't work)
+Please make an exception for the miners folders location in your antivirus software and the program should work without problems.
 If you still experience problems related to antivirus software, please do contact your antivirus provider company.
 
-Users have also reported some issues with ASUS routers. ASUS routers utilize "AiProtection" ("Vulnerability Protection" on older models) to block Crypto Miner communication with stratum servers. 
+Users have also reported some issues with ASUS routers. ASUS routers utilize "AiProtection" ("Vulnerability Protection" on older models) to block Crypto Miner communication with stratum servers.
 If you are using ASUS router and you have issues with timeouts, try to disable ASUS AiProtection.

--- a/mining_tool_instruction/others/en.html
+++ b/mining_tool_instruction/others/en.html
@@ -1,5 +1,5 @@
 Freedom! tries to work with many different antivirus companies to whitelist the official Crypto miner software. 
-Sometimes we still get a false positive and the antivirus software will block the installation or normal operation of the program. 
+Sometimes we still get a false positive and the antivirus software will block the installation or normal operation of the program. (Take note: That Kaspersky is one of the know antivirus that doesn't work) 
 Please make an exception for the miners folders location in your antivirus software and the program should work without problems. 
 If you still experience problems related to antivirus software, please do contact your antivirus provider company.
 


### PR DESCRIPTION
### Ticket
- [Kaspersky deletes Ignis upon download](https://trello.com/c/W88bo3Tc)

### Summary of Changes
- Updated "others" instruction
  - Included Kapersky as specified AV that does not work.